### PR TITLE
Create a rake task & service for incomplete_works

### DIFF
--- a/app/services/incomplete_works_service.rb
+++ b/app/services/incomplete_works_service.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+# IncompleteWorksService is responsible for generating reports on incomplete works
+# in the digital collections. It identifies attachments without filesets
+# and works without attachments, generating CSV files for each report.
+#
+# Usage:
+#   IncompleteWorksService.run_reports
+#   IncompleteWorksService.run_reports(reports: [:no_files])
+#
+# This will create the specified CSV files in the public/uploads directory.
+class IncompleteWorksService
+  # Run the reports to find incomplete works
+  #
+  # @return [void]
+  #
+  # Generates two CSV files:
+  # - attachments_without_filesets.csv: Lists attachments without associated filesets.
+  # - works_without_attachments.csv: Lists works that do not have any attachments.
+  def self.run_reports(reports: %i[no_files no_attachments], rows: 100_000)
+    # Create CSV for attachments without filesets
+    if reports.include?(:no_files)
+      create_csv(data: no_files(rows: rows),
+                 output_file: 'attachments_without_filesets.csv',
+                 headers: ["Attachment URL", "Work Type", "Bulkrax Identifier", "Parent URL"])
+    end
+
+    return unless reports.include?(:no_attachments)
+    # Create CSV for works without attachments
+    create_csv(data: no_attachments(rows: rows),
+               output_file: 'works_without_attachments.csv',
+               headers: ["Work URL", "Work Type", "Bulkrax Identifier"])
+  end
+
+  # Find all attachments without members
+  def self.no_files(rows: 100_000)
+    results = Hyrax::SolrService.query(
+      "has_model_ssim:Attachment AND -file_set_ids_ssim:[* TO *] AND is_page_of_ssim:[* TO *]",
+      rows: rows,
+      fl: 'id,is_page_of_ssim,bulkrax_identifier_tesim'
+    )
+
+    results.map do |hash|
+      parent_model = Hyrax::SolrService.query(
+        "id:#{hash['is_page_of_ssim'].first}",
+        rows: 1
+      ).first['has_model_ssim'].first
+      parent_id = hash['is_page_of_ssim'].first
+
+      "https://digitalcollections.lib.utk.edu/concern/parent/#{parent_id}/attachments/#{hash['id']};" \
+      "#{parent_model};" \
+      "#{hash['bulkrax_identifier_tesim']&.first};" \
+      "https://digitalcollections.lib.utk.edu/concern/#{parent_model.underscore.pluralize}/#{parent_id}"
+    end
+  end
+
+  def self.no_attachments(rows: 100_000)
+    results = []
+    (Hyrax.config.curation_concerns - [Attachment]).each do |concern|
+      results << Hyrax::SolrService.query(
+        "has_model_ssim:#{concern} AND -member_ids_ssim:[* TO *]",
+        rows: rows,
+        fl: 'id,bulkrax_identifier_tesim,has_model_ssim'
+      )
+    end
+
+    results.flatten.map do |hash|
+      "https://digitalcollections.lib.utk.edu/concern/#{hash['has_model_ssim'].first.downcase.pluralize}/" \
+      "#{hash['id']};" \
+      "#{hash['has_model_ssim'].first};" \
+      "#{hash['bulkrax_identifier_tesim']&.first}"
+    end
+  end
+
+  def self.create_csv(data:, output_file:, headers:)
+    # Set file path in public directory
+    file_path = Rails.root.join('public', 'uploads', output_file)
+
+    CSV.open(file_path, "wb") do |csv|
+      # Add a header row if needed
+      csv << headers
+
+      # Process each string in the array
+      data.each do |str|
+        parts = str.split(';')
+        csv << parts
+      end
+    end
+  end
+end

--- a/lib/tasks/incomplete_works.rake
+++ b/lib/tasks/incomplete_works.rake
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+namespace :hyku do
+  desc "Create no_files or no_attachments incomplete work reports"
+  task :incomplete_works, %i[tenant reports rows] => :environment do |_t, args|
+    begin
+      tenant = args[:tenant]
+
+      # Validate that tenant is provided
+      if tenant.blank?
+        puts "ERROR: Account tenant name must be provided as an argument"
+        puts "Examples:"
+        puts "  rake hyku:incomplete_works[tenant]                  # Run all reports with default row limit"
+        puts "  rake hyku:incomplete_works[tenant,no_files]         # Run only no_files report"
+        puts "  rake hyku:incomplete_works[tenant,no_attachments]   # Run only no_attachments report"
+        puts "  rake hyku:incomplete_works[tenant,no_files,500]     # Run no_files report with 500 row limit"
+        puts "  rake hyku:incomplete_works[tenant,,500]             # Run all reports, each with 500 row limit"
+        exit(1)
+      end
+
+      # Validate report types
+      reports = args[:reports] ? args[:reports].split(',').map(&:to_sym) : %i[no_files no_attachments]
+
+      valid_reports = %i[no_files no_attachments]
+      invalid_reports = reports - valid_reports
+
+      if invalid_reports.any?
+        puts "ERROR: Invalid report type(s): #{invalid_reports.join(', ')}"
+        puts "Valid report types are: #{valid_reports.join(', ')}"
+        exit(1)
+      end
+
+      # Validate row limit is a positive integer
+      rows = if args[:rows].present?
+               if args[:rows].match?(/\A\d+\z/) && args[:rows].to_i.positive?
+                 args[:rows].to_i
+               else
+                 puts "ERROR: Row limit must be a positive integer if provided."
+                 puts "You provided: '#{args[:rows]}'"
+                 exit(1)
+               end
+             else
+               100_000 # Default row limit
+             end
+
+      # Validate that tenant exists
+      account = Account.find_by(name: tenant)
+      if account.nil?
+        puts "ERROR: Account with name '#{tenant}' not found."
+        puts "Please ensure the tenant name is correct and the account exists."
+        exit(1)
+      end
+
+      switch!(account)
+      IncompleteWorksService.run_reports(reports: reports, rows: rows)
+
+      puts "Reports generated successfully in public/uploads directory."
+      puts "Check the following files:"
+      reports.each do |report|
+        case report
+        when :no_files
+          puts "  /uploads/attachments_without_filesets.csv"
+        when :no_attachments
+          puts "  /uploads/works_without_attachments.csv"
+        end
+      end
+    rescue StandardError => e
+      puts "ERROR: An error occurred while generating reports:"
+      puts e.message
+      puts e.backtrace[0..5].join("\n") # Show first 6 lines of backtrace
+      exit(1)
+    end
+  end
+end


### PR DESCRIPTION
# Story

Refs #761 

This creates a service to run several error-identifying solr queries, and export the results to csv files.

# Expected Behavior Before Changes

# Expected Behavior After Changes
Creates a rake task to generate CSV files with errors. Files can be downloaded at:
`/uploads/attachments_without_filesets.csv` and `/uploads/works_without_attachments.csv`

```
     rake hyku:incomplete_works[tenant]                  # Run all reports with default row limit
     rake hyku:incomplete_works[tenant,no_files]         # Run only no_files report
     rake hyku:incomplete_works[tenant,no_attachments]   # Run only no_attachments report
     rake hyku:incomplete_works[tenant,no_files,500]     # Run no_files report with 500 row limit
     rake hyku:incomplete_works[tenant,,500]             # Run both reports with 500 row limits
```
