### PR TITLE
Use update callbacks to update FileSet visibility

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -6,6 +6,8 @@ class Attachment < ActiveFedora::Base
   include SharedWorkBehavior
   include IiifPrint.model_configuration
 
+  after_update :update_file_set_visibility
+
   self.indexer = AttachmentIndexer
 
   # Change this to restrict which works can be added as a child.
@@ -16,5 +18,14 @@ class Attachment < ActiveFedora::Base
     return false if rdf_type.blank?
 
     Hyrax::ConditionalDerivativeDecorator.intermediate_file?(object: self)
+  end
+
+  # If we update the Attachment's visibility, we should also update the FileSet's visibility
+  def update_file_set_visibility
+    file_sets.each do |fs|
+      next if visibility == fs.visibility
+
+      fs.update!(visibility: visibility)
+    end
   end
 end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -22,10 +22,6 @@ class Attachment < ActiveFedora::Base
 
   # If we update the Attachment's visibility, we should also update the FileSet's visibility
   def update_file_set_visibility
-    file_sets.each do |fs|
-      next if visibility == fs.visibility
-
-      fs.update!(visibility: visibility)
-    end
+    ::VisibilityCopyJob.perform_later(self)
   end
 end

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -31,4 +31,18 @@ RSpec.describe Attachment do
       end
     end
   end
+
+  describe '#update' do
+    context 'with a connected FileSet' do
+      let(:attachment) { FactoryBot.create(:attachment_with_one_file, visibility: 'restricted') }
+
+      it 'updates the visibility of the connected FileSet' do
+        expect(attachment.visibility).to eq('restricted')
+        expect(attachment.file_sets.first.visibility).to eq('restricted')
+        attachment.update!(visibility: 'open')
+        expect(attachment.reload.visibility).to eq('open')
+        expect(attachment.file_sets.first.reload.visibility).to eq('open')
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Story
We would like to update a work's FileSet's visibility via Bulkrax
Refs #782

# Expected Behavior Before Changes
Updating the Attachment's visibility does not change the FileSet's visibility, as expected, and in order to update the FileSet's visibility, Bulkrax tries to re-import all the original files, which may not be available.

# Expected Behavior After Changes
When updating the Attachment via Bulkrax, the FileSet's visibility is automatically updated to match that of the Attachment, meaning that the FileSet's visibility does not need to be updated separately.
