### PR TITLE
Do not require a file_name if a FileSet is being updated

### DIFF
--- a/app/models/concerns/bulkrax/file_set_entry_behavior_decorator.rb
+++ b/app/models/concerns/bulkrax/file_set_entry_behavior_decorator.rb
@@ -8,7 +8,7 @@ module Bulkrax
       factory.find.present?
     end
 
-    # Do no raise an error if this is an update
+    # Do not raise an error if this is an update
     def validate_presence_of_filename!
       return if parsed_metadata&.[](file_reference)&.map(&:present?)&.any?
 

--- a/app/models/concerns/bulkrax/file_set_entry_behavior_decorator.rb
+++ b/app/models/concerns/bulkrax/file_set_entry_behavior_decorator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# OVERRIDE
+module Bulkrax
+  module FileSetEntryBehaviorDecorator
+    # If the object already exists, this is an object update
+    def update?
+      factory.find.present?
+    end
+
+    # Do no raise an error if this is an update
+    def validate_presence_of_filename!
+      return if parsed_metadata&.[](file_reference)&.map(&:present?)&.any?
+
+      raise StandardError, 'File set must have a filename' unless update?
+    end
+  end
+end
+
+Bulkrax::FileSetEntryBehavior.prepend(Bulkrax::FileSetEntryBehaviorDecorator)

--- a/spec/factories/bulkrax/bulkrax_entries.rb
+++ b/spec/factories/bulkrax/bulkrax_entries.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bulkrax_csv_entry, class: 'Bulkrax::CsvEntry' do
+    identifier { "csv_entry" }
+    type { 'Bulkrax::CsvEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+
+  factory :bulkrax_csv_entry_file_set, class: 'Bulkrax::CsvFileSetEntry' do
+    identifier { 'file_set_entry_1' }
+    type { 'Bulkrax::CsvFileSetEntry' }
+    importerexporter { FactoryBot.build(:bulkrax_importer) }
+    raw_metadata { {} }
+    parsed_metadata { {} }
+  end
+end

--- a/spec/factories/bulkrax/bulkrax_importer_runs.rb
+++ b/spec/factories/bulkrax/bulkrax_importer_runs.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bulkrax_importer_run, class: 'Bulkrax::ImporterRun' do
+    importer { FactoryBot.build(:bulkrax_importer) }
+    total_work_entries { 1 }
+    enqueued_records { 1 }
+    processed_records { 0 }
+    deleted_records { 0 }
+    failed_records { 0 }
+  end
+end

--- a/spec/factories/bulkrax/bulkrax_importers.rb
+++ b/spec/factories/bulkrax/bulkrax_importers.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bulkrax_importer, class: 'Bulkrax::Importer' do
+    name { 'CSV Import' }
+    admin_set_id { AdminSet.find_or_create_default_admin_set_id }
+    user { FactoryBot.build(:base_user) }
+    frequency { 'PT0S' }
+    parser_klass { 'Bulkrax::CsvParser' }
+    limit { 10 }
+    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/good.csv' } }
+    field_mapping { Bulkrax.config.field_mappings["Bulkrax::CsvParser"] }
+    after :create, &:current_run
+
+    trait :with_relationships_mappings do
+      field_mapping do
+        {
+          'parents' => { 'from' => ['parents_column'], split: /\s*[|]\s*/, related_parents_field_mapping: true },
+          'children' => { 'from' => ['children_column'], split: /\s*[|]\s*/, related_children_field_mapping: true }
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/csv/good.csv
+++ b/spec/fixtures/csv/good.csv
@@ -1,0 +1,2 @@
+source_identifier,model,title,parents
+1234-5678,FileSet,"Updated FileSet title",

--- a/spec/models/concerns/bulkrax/file_set_entry_behavior_decorator_spec.rb
+++ b/spec/models/concerns/bulkrax/file_set_entry_behavior_decorator_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Bulkrax::FileSetEntryBehaviorDecorator, type: :model, clean: true do
+  let(:entry) do
+    FactoryBot.create(:bulkrax_csv_entry_file_set)
+  end
+
+  it 'uses the locally defined methods' do
+    expect(entry.method(:validate_presence_of_filename!).owner).to eq(described_class)
+  end
+
+  describe 'updates' do
+    context 'without a remote file' do
+      let(:attachment) do
+        Attachment.create!(
+          title: ["Test Attachment title"],
+          visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
+          state: "complete",
+          bulkrax_identifier: 'attachment_1'
+        )
+      end
+      let(:file_set) do
+        FileSet.create!(
+          title: ['FileSet pre-update'],
+          bulkrax_identifier: 'file_set_entry_1'
+        )
+      end
+      let(:entry) do
+        Bulkrax::CsvFileSetEntry.create(
+          identifier: 'file_set_entry_1',
+          type: 'Bulkrax::CsvFileSetEntry',
+          importerexporter: FactoryBot.create(:bulkrax_importer),
+          raw_metadata: { model: 'FileSet', title: "Updated FileSet title",
+                          source_identifier: 'file_set_entry_1', parents: 'attachment_1' },
+          parsed_metadata: {}
+        )
+      end
+
+      before do
+        attachment.ordered_members << file_set
+        attachment.save!
+      end
+
+      around do |example|
+        entry
+        cached_adapter = ActiveJob::Base.queue_adapter
+        cached_perform_enqueued_jobs = ActiveJob::Base.queue_adapter.perform_enqueued_jobs
+        ActiveJob::Base.queue_adapter = :test
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+        example.run
+        ActiveJob::Base.queue_adapter = cached_adapter
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = cached_perform_enqueued_jobs
+      end
+
+      it 'does not raise an error' do
+        expect(file_set.title).to eq(['FileSet pre-update'])
+        expect(file_set.bulkrax_identifier).to eq('file_set_entry_1')
+        entry.build_for_importer
+        expect(entry.status_message).to eq('Complete')
+        expect(entry.error_class).to be_nil
+        expect(entry.update?).to be true
+        expect(file_set.reload.title).to eq(['Updated FileSet title'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Story

Refs #782

# Expected Behavior Before Changes
Trying to update a FileSet using Bulkrax without a remote_files link does not work and raises an error. 

# Expected Behavior After Changes
When a FileSet has already been created via a previous import, updating it via Bulkrax does not require a remote_files link.

# Screenshots / Video
FileSet that was initially imported with Bulkrax subsequently updated with Bulkrax without a remote_files link
<img width="1204" height="617" alt="image" src="https://github.com/user-attachments/assets/f81ad107-f73a-4cd2-8b17-57da9e3d3af9" />
