### PR TITLE
🧹 Bring back UV download button

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,4 +140,18 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   # Use proxy URL for S3 content to avoid CORS issues
   # see #create_supplementing_content in app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
   get 'supplementing_content/:id(.:format)', to: 'supplementing_content#show', as: 'supplementing_content'
+
+  # TODO: this route is a temporary fix for UV small image download not working
+  get '/:file_path/full/:size/:rotation/:quality.:format',
+    to: redirect { |params, request|
+      encoded_path = params[:file_path].gsub('/', '%2F')
+      "/images/#{encoded_path}/full/#{params[:size]}/#{params[:rotation]}/#{params[:quality]}.#{params[:format]}"
+    },
+    constraints: {
+      file_path: /[a-f0-9-]+%2Ffiles%2F[a-f0-9-]+%2Ffcr:versions%2F\w+/,
+      size: /[\d,!]+/,
+      rotation: /\d+/,
+      quality: /\w+/,
+      format: /(jpg|png|gif|webp)/
+    }
 end

--- a/config/uv/uv-config.json
+++ b/config/uv/uv-config.json
@@ -1,9 +1,3 @@
 {
-  "modules": {
-    "footerPanel": {
-      "options": {
-        "downloadEnabled": false
-      }
-    }
-  }
+
 }


### PR DESCRIPTION
Originally we hid the UV download button because the small image download option was not working.  This commit will add a route redirect workaround until we find the actual solution.  This way the download button will function again.

Ref:
- https://github.com/notch8/utk-hyku/issues/790

![utk-uv-download](https://github.com/user-attachments/assets/891c8892-3137-4891-9203-70a65b2804fc)
