### PR TITLE
🐛 Fix not being able to delete works with Bulkrax

### DIFF
--- a/app/services/bulkrax/factory_class_finder_decorator.rb
+++ b/app/services/bulkrax/factory_class_finder_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# OVERRIDE Bulkrax v9.0.2 to ensure parsed_metadata is set when calling for the name of the class
+
+module Bulkrax
+  module FactoryClassFinderDecorator
+    def name
+      entry.build_metadata if entry.parsed_metadata.blank?
+
+      super
+    end
+  end
+end
+
+Bulkrax::FactoryClassFinder.prepend(Bulkrax::FactoryClassFinderDecorator)


### PR DESCRIPTION
This commit will add an override for the #find method in the `Bulkrax::FactoryClassFinder`.  We we getting the name set to the default type of `GenericWork` because it tries to look in the `parsed_metadata` for the `model` but if we don't have any `parsed_metadata` at that point then it does the fallback.

Ref:
- https://github.com/notch8/utk-hyku/issues/784
