### PR TITLE
Update footer links to match new main website 

### DIFF
--- a/app/views/themes/dc_repository/shared/_footer.html.erb
+++ b/app/views/themes/dc_repository/shared/_footer.html.erb
@@ -23,25 +23,10 @@
               <div class="utk-resources-menu--section">
                 <ul class="utk-resources-menu--submenu">
                   <li>
-                    <a href="https://www.lib.utk.edu/about/administration">Administration</a>
+                    <a href="https://maps.utk.edu/?id=314#!ce/3040?ct/27641?m/276034?s/">Map & Directions</a>
                   </li>
                   <li>
-                    <a href="https://www.lib.utk.edu/contact/">Contact UT Libraries</a>
-                  </li>
-                  <li>
-                    <a href="https://www.lib.utk.edu/contact/website-feedback/">Comments &amp; Feedback</a>
-                  </li>
-                  <li>
-                    <a href="https://libanswers.utk.edu/systems/">System Status</a>
-                  </li>
-                  <li>
-                    <a href="https://www.lib.utk.edu/about/policies/web-privacy/">Privacy Policy</a>
-                  </li>
-                  <li>
-                    <a href="https://www.lib.utk.edu/intranet/">Staff Only</a>
-                  </li>
-                  <li>
-                    <a href="https://bigorangegive.utk.edu/libraries/">Give to UT Libraries</a>
+                    <a href="https://give.utk.edu/campaigns/42950/donations/new?designation_id=anutk_lib">Give to the Libraries</a>
                   </li>
                 </ul>
               </div>
@@ -51,42 +36,23 @@
         <div class="footer-libraries--menu d-flex">
           <div class="utk-resources-menu--col">
             <div class="utk-resources-menu--section">
-              <h2 class="utk-resources-menu--trigger">Find Materials</h2>
+              <h2 class="utk-resources-menu--trigger">About</h2>
               <div class="utk-resources-menu--submenu d-flex">
-                <a href="https://www.lib.utk.edu/onesearch/" rel="canonical">One Search</a>
-                <a href="https://www.lib.utk.edu/databases/" rel="canonical">Articles &amp; Databases</a>
-                <a href="https://www.lib.utk.edu/finding-ejournals/">E-Journals</a>
-                <a href="https://www.lib.utk.edu/access/course-reserves/">Course Reserves</a>
-                <a href="https://digital.lib.utk.edu/">Digital Collections</a>
-                <a href="https://www.lib.utk.edu/special/">Special Collections</a>
-                <a href="https://libguides.utk.edu/az.php?s=55546">UT Dissertations</a>
+                <a href="https://lib.utk.edu/about" rel="canonical">About the Libraries</a>
+                <a href="https://lib.utk.edu/society/" rel="canonical">John C. Hodges Society</a>
+                <a href="https://volumes.lib.utk.edu/features/"><i>Speaking Volumes</i></a>
+                <a href="https://lib.utk.edu/department/community-learning-and-engagement">Outreach</a>
               </div>
             </div>
           </div>
           <div class="utk-resources-menu--col">
             <div class="utk-resources-menu--section">
-              <h2 class="utk-resources-menu--trigger">Research</h2>
+              <h2 class="utk-resources-menu--trigger">Contact</h2>
               <div class="utk-resources-menu--submenu d-flex">
-                <a href="https://www.lib.utk.edu/askusnow/subject-librarians/">Subject Librarians</a>
-                <a href="https://www.lib.utk.edu/askusnow/appointment/">Research Consultation</a>
-                <a href="https://libguides.utk.edu/">Research Guides</a>
-                <a href="https://lib.utk.edu/info/research">Research Tools</a>
-                <a href="https://www.lib.utk.edu/scholar/">Scholars’ Collaborative</a>
-                <a href="https://libguides.utk.edu/style/">Citing Sources</a>
-                <a href="https://libguides.utk.edu/citeman/">EndNote / Zotero</a>
-              </div>
-            </div>
-          </div>
-          <div class="utk-resources-menu--col">
-            <div class="utk-resources-menu--section">
-              <h2 class="utk-resources-menu--trigger">Resources</h2>
-              <div class="utk-resources-menu--submenu d-flex">
-                <a href="https://www.lib.utk.edu/instruct/">Teaching &amp; Learning</a>
-                <a href="https://www.lib.utk.edu/access/borrow-renew/">Borrow &amp; Renew</a>
-                <a href="https://libguides.utk.edu/databases/490">Google Scholar</a>
-                <a href="https://www.lib.utk.edu/info/tech/">Technology Support</a>
-                <a href="https://libguides.utk.edu/tutorials">Tutorials</a>
-                <a href="https://libanswers.utk.edu/">Get Help</a>
+                <a href="https://lib.utk.edu/directory">Directory</a>
+                <a href="https://lib.utk.edu/employment">Employment</a>
+                <a href="https://lib.utk.edu/about/policies">Policies</a>
+                <a href="https://liveutk.sharepoint.com/sites/ut_libraryadministration/SitePages/Quick-Links.aspx">Staff Only</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
# Story
We at UTK released out new main website and made some changes to the footer and our general site structure.  I'm just making some updates to the footer links to match those changes.

Refs #issuenumber

# Expected Behavior Before Changes
Links navigated to various UTK websites.  Some of which 404 because they no longer exist.

# Expected Behavior After Changes
Links all navigate to existing pages and more closely match current footer link layout. 

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes