### PR TITLE
Fixes IiifPrint behavior

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'
 gem 'blacklight_range_limit', '~> 7.0'
 gem 'bolognese', '>= 1.9.10'
 gem 'bootstrap-datepicker-rails'
-gem 'bulkrax', github: 'samvera/bulkrax', ref: '03d7e8bf87e52777321ae2d572bd5d221ca40f5c'
+gem 'bulkrax', github: 'samvera/bulkrax', branch: 'utk'
 gem 'byebug', group: %i[development test]
 gem 'capybara', group: %i[test]
 gem 'capybara-screenshot', '~> 1.0', group: %i[test]
@@ -45,7 +45,7 @@ gem 'i18n', '1.11.0' # TODO: why does updating to 1.14.1 break allinson flex?
 gem 'i18n-debug', require: false, group: %i[development test]
 gem 'i18n-tasks', group: %i[development test]
 gem 'iiif_manifest', git: 'https://github.com/samvera/iiif_manifest.git', ref: 'e5d8a2d'
-gem 'iiif_print', github: 'notch8/iiif_print', branch: 'main'
+gem 'iiif_print', github: 'notch8/iiif_print', ref: '5c5fa6880b3dc22beed738cfcba7af57b698ac36'
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 # The maintainers yanked 0.3.2 version (see https://github.com/dryruby/json-canonicalization/issues/2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 GIT
   remote: https://github.com/notch8/iiif_print.git
   revision: 5c5fa6880b3dc22beed738cfcba7af57b698ac36
-  branch: main
+  ref: 5c5fa6880b3dc22beed738cfcba7af57b698ac36
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (>= 1.0, < 3.0)
@@ -53,8 +53,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera/bulkrax.git
-  revision: 03d7e8bf87e52777321ae2d572bd5d221ca40f5c
-  ref: 03d7e8bf87e52777321ae2d572bd5d221ca40f5c
+  revision: f1c302409564ace06c5745596ae01562d531e9d2
+  branch: utk
   specs:
     bulkrax (9.0.2)
       bagit (~> 0.6.0)
@@ -428,7 +428,7 @@ GEM
       activerecord (>= 4.1.14, < 8.0.0)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.5.2)
+    derivative-rodeo (0.5.3)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs
@@ -775,7 +775,7 @@ GEM
       rdf-vocab (~> 3.0)
     legato (0.7.0)
       multi_json
-    libxml-ruby (5.0.4)
+    libxml-ruby (5.0.5)
     link_header (0.0.8)
     linkeddata (3.1.6)
       equivalent-xml (~> 0.6)

--- a/app/jobs/iiif_print/child_works_from_pdf_job_decorator.rb
+++ b/app/jobs/iiif_print/child_works_from_pdf_job_decorator.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# OVERRIDE IiifPrint 1.0.0 to log serialization issues before submitting BatchCreateJob
+module IiifPrint
+  module Jobs
+    module ChildWorksFromPdfJobDecorator
+      def split_pdf(original_pdf_path, user, child_model, pdf_file_set)
+        image_files = @parent_work.iiif_print_config.pdf_splitter_service.call(original_pdf_path,
+                                                                               file_set: pdf_file_set)
+
+        # give as much info as possible if we don't have image files to work with.
+        if image_files.blank?
+          raise "#{@parent_work.class} (ID=#{@parent_work.id} " /
+                "to_param:#{@parent_work.to_param}) " /
+                "original_pdf_path #{original_pdf_path.inspect} " /
+                "pdf_file_set #{pdf_file_set.inspect}"
+        end
+
+        @split_from_pdf_id = pdf_file_set&.id
+        prepare_import_data(original_pdf_path, image_files, user)
+
+        # submit the job to create all the child works for one PDF
+        # @param [User] user
+        # @param [Hash<String => String>] titles
+        # @param [Hash<String => String>] resource_types (optional)
+        # @param [Array<String>] uploaded_files Hyrax::UploadedFile IDs
+        # @param [Hash] attributes attributes to apply to all works, including :model
+        # @param [Hyrax::BatchCreateOperation] operation
+        operation = Hyrax::BatchCreateOperation.create!(
+          user: user,
+          operation_type: "PDF Batch Create"
+        )
+
+        ## Inspect attributes to find ActiveTriples::Relation errors
+        merged_attrs = attributes.merge!(model: child_model.to_s,
+                                         split_from_pdf_id: @split_from_pdf_id)
+                                 .with_indifferent_access
+        # Check for ActiveTriples in attributes
+        check_for_active_triples(merged_attrs)
+        ## End inspect attributes
+
+        BatchCreateJob.perform_later(user,
+                                     @child_work_titles,
+                                     {},
+                                     @uploaded_files,
+                                     merged_attrs,
+                                     operation)
+      end
+
+      private
+
+        def check_for_active_triples(hash, path = "")
+          hash.each do |key, value|
+            current_path = path.empty? ? key.to_s : "#{path}.#{key}"
+            # rubocop:disable Style/GuardClause
+            if value.is_a?(ActiveTriples::Relation)
+              raise "Found ActiveTriples::Relation at attributes[#{current_path}]: #{value.inspect}\n
+              Value class: #{value.class}\nTo fix: convert to array with .to_a or string with .first"
+            elsif value.is_a?(Hash)
+              check_for_active_triples(value, current_path)
+            elsif value.is_a?(Array)
+              value.each_with_index do |item, index|
+                if item.is_a?(ActiveTriples::Relation)
+                  raise "Found ActiveTriples::Relation at attributes[#{current_path}][#{index}]: #{item.inspect}"
+                elsif item.is_a?(Hash)
+                  check_for_active_triples(item, "#{current_path}[#{index}]")
+                end
+              end
+            end
+            # rubocop:enable Style/GuardClause
+          end
+        rescue StandardError => e
+          error_msg = "ActiveTriples detection: #{e.message}\n
+                      \nFull attributes:
+                      \n#{JSON.pretty_generate(sanitize_for_json(hash))}"
+          # rubocop:disable Style/RaiseArgs
+          raise StandardError.new(error_msg)
+          # rubocop:enable Style/RaiseArgs
+        end
+
+        def sanitize_for_json(obj)
+          case obj
+          when Hash
+            obj.transform_values { |v| sanitize_for_json(v) }
+          when Array
+            obj.map { |v| sanitize_for_json(v) }
+          when ActiveTriples::Relation
+            "[ActiveTriples::Relation: #{obj.class.name}]"
+          else
+            obj.to_s
+          end
+        end
+    end
+  end
+end
+
+IiifPrint::Jobs::ChildWorksFromPdfJob.prepend(IiifPrint::Jobs::ChildWorksFromPdfJobDecorator)

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -2,6 +2,7 @@
 
 # OVERRIDE here to add featured collection methods and to delegate collection presenters to the member presenter factory
 # OVERRIDE Hyrax 3.6 to show items in sequence order
+# OVERRIDE Hyrax 3.6 to correctly determine if IIIF media is present
 
 module Hyku
   class WorkShowPresenter < Hyrax::WorkShowPresenter
@@ -56,15 +57,34 @@ module Hyku
     end
     # End Featured Collections Methods
 
-    def iiif_media?(presenter: representative_presenter)
-      presenter.image? || presenter.video? || presenter.audio?
+    ## OVERRIDE to allow IIIF media to be correctly shown in universal viewer
+    def iiif_viewer?
+      Hyrax.config.iiif_image_server? &&
+        representative_id.present? &&
+        representative_presenter.present? &&
+        iiif_media? &&
+        members_include_iiif_viewable?
     end
 
-    def members_include_viewable?
-      file_set_presenters.any? do |presenter|
+    def iiif_media?(presenter: representative_presenter)
+      iiif_media_predicates = %i[image? audio? video? pdf?]
+      iiif_media_predicates.any? do |predicate|
+        presenter.try(predicate) ||
+          presenter.try(:solr_document).try(predicate)
+      end
+    end
+
+    def members_include_iiif_viewable?
+      iiif_presentable_member_presenters.any? do |presenter|
         iiif_media?(presenter: presenter) && current_ability.can?(:read, presenter.id)
       end
     end
+
+    def iiif_presentable_member_presenters
+      presentable_member_ids = Array.wrap(solr_document.try(:member_ids) || solr_document.try(:[], 'member_ids_ssim'))
+      member_presenters(presentable_member_ids)
+    end
+    # end OVERRIDE Hyrax 3.6 to correctly determine if IIIF media is present
 
     # OVERRIDE Hyrax 3.6 to show items in sequence order
     # list of item ids to display is based on ordered_ids


### PR DESCRIPTION
# Story
- [Updates Bulkrax](https://github.com/samvera/bulkrax/compare/main...utk) to correctly handle PDF splitting (ensure that import_url is saved on the file_set).
- Updates work presenter logic to determine if IIIF media is present for universal viewer display.
- adds logging to ChildWorksFromPdfJob in case serialization failures recur

Refs https://github.com/notch8/utk-hyku/issues/804

# Expected Behavior Before Changes

- PDF files with models GenericWork or Pdf did not split child works.
- Works with with split child works did not display in universal viewer.

# Expected Behavior After Changes
- PDF files with models GenericWork or Pdf split into child works.
- Works with with split child works display in universal viewer.

# Screenshots / Video

<details>
<summary>Screenshot</summary>

<img width="1794" height="5396" alt="screencapture-cat-utk-hyku-test-concern-pdfs-02b92604-0c82-483d-a9cd-03b6a4d31819-2025-11-12-21_31_23" src="https://github.com/user-attachments/assets/5c7c55a0-62d9-49e2-886b-c0420904c755" />

</details>

# Notes