### PR TITLE
More oai mods changes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -427,9 +427,9 @@ class CatalogController < ApplicationController
       },
       document: {
         limit: 100, # number of records returned with each request, default: 15
-        set_fields: [ # ability to define ListSets, optional, default: nil
-          { label: 'admin_set', solr_field: 'isPartOf_ssim' },
-          { label: 'collection', solr_field: 'member_of_collections_ssim' }
+        set_fields: [ # must contain terms that are identifiers in order for list_sets_decorator to work properly
+          { label: 'admin_set', solr_field: 'isPartOf_ssim', description: 'Items grouped by admin set' },
+          { label: 'collection', solr_field: 'member_of_collection_ids_ssim', description: 'Items grouped by collection' }
         ]
       }
     }

--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -51,7 +51,7 @@ module ModsSolrDocument
   end
 
   private
-  
+
     def converter
       @converter ||= UriToStringConverterService.new(self)
     end
@@ -165,7 +165,7 @@ module ModsSolrDocument
     def load_access(xml)
       access_terms.each do |access_term|
         Array.wrap(send(access_term))&.each do |access|
-          xml.accessCondition(type: access_term.to_s, "xlink:href" => access) do
+          xml.accessCondition(type: 'use_and_reproduction', "xlink:href" => access) do
             xml.text converter.convert_uri_to_value([access_term]).first
           end
         end

--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -51,6 +51,9 @@ module ModsSolrDocument
   end
 
   private
+    def converter
+      @converter ||= UriToStringConverterService.new(self)
+    end
 
     def oai_url
       tenant_url + "/catalog/oai"
@@ -161,7 +164,10 @@ module ModsSolrDocument
     def load_access(xml)
       access_terms.each do |access_term|
         Array.wrap(send(access_term))&.each do |access|
-          xml.accessCondition(type: 'use and reproduction', "xlink:href" => access)
+          access_text = converter.convert_uri_to_value([access_term]).first || ''
+          xml.accessCondition(type: access_term.to_s, "xlink:href" => access) do
+            xml.text access_text
+          end
         end
       end
     end

--- a/app/models/concerns/mods_solr_document.rb
+++ b/app/models/concerns/mods_solr_document.rb
@@ -51,6 +51,7 @@ module ModsSolrDocument
   end
 
   private
+  
     def converter
       @converter ||= UriToStringConverterService.new(self)
     end
@@ -164,9 +165,8 @@ module ModsSolrDocument
     def load_access(xml)
       access_terms.each do |access_term|
         Array.wrap(send(access_term))&.each do |access|
-          access_text = converter.convert_uri_to_value([access_term]).first || ''
           xml.accessCondition(type: access_term.to_s, "xlink:href" => access) do
-            xml.text access_text
+            xml.text converter.convert_uri_to_value([access_term]).first
           end
         end
       end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -217,6 +217,7 @@ class SolrDocument
     end
 
     def sanitize_hash(document_hash)
+      return document_hash if document_hash.blank?
       document_hash.each_value do |_key, value|
         Array.wrap(value).map! do |v|
           v == '[]' ? nil : v

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -218,7 +218,7 @@ class SolrDocument
 
     def sanitize_hash(document_hash)
       return document_hash if document_hash.blank?
-      document_hash.each_value do |_key, value|
+      document_hash.each_value do |value|
         Array.wrap(value).map! do |v|
           v == '[]' ? nil : v
         end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -34,6 +34,15 @@ class SolrDocument
   attribute :rendering_ids, Solr::Array, 'hasFormat_ssim'
   attribute :account_cname, Solr::Array, 'account_cname_tesim'
 
+  def initialize(*args)
+    # past importing created some '[]' string values in the model, which
+    # appear as empty arrays in OAI feed and other views. We sanitize them
+    # because fixing in fedora would be monumental.
+    # @TODO: once migrated to postgres, fix the data at the source.
+    sanitize_hash(args.first)
+    super
+  end
+
   def date_created_d
     self['date_created_d_tesim']
   end
@@ -205,6 +214,15 @@ class SolrDocument
       host = self['account_cname_tesim'].first
 
       "https://#{host}#{path}"
+    end
+
+    def sanitize_hash(document_hash)
+      document_hash.each do |key, value|
+        Array.wrap(value).map! do |v|
+          v == '[]' ? nil : v
+        end
+      end
+      document_hash
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -217,7 +217,7 @@ class SolrDocument
     end
 
     def sanitize_hash(document_hash)
-      document_hash.each do |key, value|
+      document_hash.each_value do |_key, value|
         Array.wrap(value).map! do |v|
           v == '[]' ? nil : v
         end

--- a/lib/blacklight_oai_provider/response/list_sets_decorator.rb
+++ b/lib/blacklight_oai_provider/response/list_sets_decorator.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Override BlacklightOaiProvider v6.1.1 to customize setSpec and setName for collections
+module BlacklightOaiProvider
+  module Response
+    module ListSetsDecorator
+      def initialize(*args)
+        super
+        sets = provider.model.sets
+        return unless sets
+        @lookup = initialize_set_info_for(sets)
+      end
+
+      def to_xml
+        raise OAI::SetException unless provider.model.sets
+
+        response do |r|
+          r.ListSets do
+            provider.model.sets.each do |set|
+              r.set do
+
+                r.setSpec set.spec
+                r.setName collection_name_for(set)
+
+                if set.respond_to?(:description) && set.description
+                  r.setDescription do
+                    r.tag!("#{oai_dc.prefix}:#{oai_dc.element_namespace}", oai_dc.header_specification) do
+                      r.dc :description, set.description
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def initialize_set_info_for(sets)
+        ids = sets.map(&:value)
+        hits = Hyrax::SolrService.query("id:(#{ids.join(' OR ')})", rows: ids.size, fl: 'id,primary_identifier_tesim,title_tesim')
+        hits.each_with_object({}) do |hit, hash|
+          hash[hit['id']] = hit
+        end
+      end
+
+      def collection_name_for(set)
+        name = @lookup.dig(set.value,'title_tesim')&.first
+        return set.spec unless name.present?
+        "#{set.label.titleize}: #{name}"
+      end
+    end
+  end
+end
+
+BlacklightOaiProvider::Response::ListSets.prepend(BlacklightOaiProvider::Response::ListSetsDecorator)

--- a/lib/blacklight_oai_provider/response/list_sets_decorator.rb
+++ b/lib/blacklight_oai_provider/response/list_sets_decorator.rb
@@ -18,7 +18,6 @@ module BlacklightOaiProvider
           r.ListSets do
             provider.model.sets.each do |set|
               r.set do
-
                 r.setSpec set.spec
                 r.setName collection_name_for(set)
 
@@ -37,19 +36,21 @@ module BlacklightOaiProvider
 
       private
 
-      def initialize_set_info_for(sets)
-        ids = sets.map(&:value)
-        hits = Hyrax::SolrService.query("id:(#{ids.join(' OR ')})", rows: ids.size, fl: 'id,primary_identifier_tesim,title_tesim')
-        hits.each_with_object({}) do |hit, hash|
-          hash[hit['id']] = hit
+        def initialize_set_info_for(sets)
+          ids = sets.map(&:value)
+          hits = Hyrax::SolrService.query("id:(#{ids.join(' OR ')})",
+                                          rows: ids.size,
+                                          fl: 'id,primary_identifier_tesim,title_tesim')
+          hits.each_with_object({}) do |hit, hash|
+            hash[hit['id']] = hit
+          end
         end
-      end
 
-      def collection_name_for(set)
-        name = @lookup.dig(set.value,'title_tesim')&.first
-        return set.spec unless name.present?
-        "#{set.label.titleize}: #{name}"
-      end
+        def collection_name_for(set)
+          name = @lookup.dig(set.value, 'title_tesim')&.first
+          return set.spec if name.blank?
+          "#{set.label.titleize}: #{name}"
+        end
     end
   end
 end


### PR DESCRIPTION
# Story

Addresses OAI issues.

Refs #816 and #811

# Expected Behavior Before Changes

- setSpec used collection name so it had spaces
- some dates appeared in oai_dc and mods as []
- access condition didn't have the text translation
- access condition type used the term name

# Expected Behavior After Changes

- removes spaces in the set spec by switching from title to identifier
- removes empty terms from feed
- adds text to accessCondition
- changes accessCondition type to `use_and_reproduction`

# Screenshots / Video

<details>
<summary>Screenshots</summary>

### SetSpec is changed to use collection's ID but retain collection title 
Before:
<img width="580" height="181" alt="Screenshot 2025-12-19 at 4 27 49 PM" src="https://github.com/user-attachments/assets/fe834f22-f88c-42a2-a986-49098afeb297" />

****After:****
<img width="938" height="232" alt="Screenshot 2025-12-19 at 4 27 34 PM" src="https://github.com/user-attachments/assets/3bc74dfa-5ebc-4e83-accd-692d17467b6e" />

### Blank terms removed from feed
**Before:**
<img width="749" height="347" alt="Screenshot 2025-12-19 at 4 28 57 PM" src="https://github.com/user-attachments/assets/767187e7-7b4a-4739-9ad2-33c2a21b9176" />
**After:**
<img width="644" height="349" alt="Screenshot 2025-12-19 at 4 34 26 PM" src="https://github.com/user-attachments/assets/50348d46-67b2-4bb9-8767-25e6c8d929b0" />

### accessCondition revisions
**Before:**
<img width="925" height="71" alt="Screenshot 2025-12-19 at 4 35 34 PM" src="https://github.com/user-attachments/assets/e4add1a8-68aa-4019-a8c5-77e3e3427761" />
**After:**
<img width="1202" height="146" alt="Screenshot 2025-12-19 at 4 35 11 PM" src="https://github.com/user-attachments/assets/ddb5d2cb-c202-4936-bd20-56ac85a30903" />

</details>

# Notes