### PR TITLE
🐛 Fix transcripts throwing NoMethodError

### DIFF
--- a/app/indexers/hyrax/file_set_indexer_decorator.rb
+++ b/app/indexers/hyrax/file_set_indexer_decorator.rb
@@ -10,10 +10,12 @@ module Hyrax
         solr_doc['digest_ssim'] = "urn:sha1:#{object.s3_only}" if object.s3_only.present?
         solr_doc['rdf_type_ssim'] = object.parent_works.first.rdf_type if attachment?
         if solr_doc['rdf_type_ssim']&.first == 'http://pcdm.org/use#Transcript'
-          content = object.files.first&.content&.encode('UTF-8', 'binary',
-                                                        invalid: :replace,
-                                                        undef: :replace,
-                                                        replace: '')
+          content = object.files.first&.content.try(:encode,
+                                                    'UTF-8',
+                                                    'binary',
+                                                    invalid: :replace,
+                                                    undef: :replace,
+                                                    replace: '')
           solr_doc['transcript_tsimv'] = content if content
         end
         solr_doc['all_text_tesimv'] = solr_doc['all_text_tsimv'] if solr_doc['all_text_tsimv'].present?


### PR DESCRIPTION
Sometimes we were getting a JobIOWrapper for the content of the file set files.  This would erroro out when we call #content on it.  Adding a try to get past it so we can move on to the actual content and index it onto the file set.

Ref:
- https://github.com/notch8/utk-hyku/issues/822

<img width="1533" height="684" alt="image" src="https://github.com/user-attachments/assets/7b49116e-34db-4be6-acb7-d171b64c88cd" />
