### PR TITLE
🐛 Fix Solr request being too long

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter_decorator.rb
@@ -15,7 +15,9 @@ module Hyrax
       else
         return @member_item_list_ids if @member_item_list_ids.present?
         ordered_ids = Hyrax::SolrDocument::OrderedMembers.decorate(model).ordered_member_ids
-        docs = Hyrax::SolrQueryService.new(query: ["id:(#{ordered_ids.join(' ')})"]).solr_documents(rows: 2_000_000)
+        docs = Hyrax::SolrService
+               .query("id:(#{ordered_ids.join(' ')})", rows: 2_000_000, method: :post)
+               .map { |hit| ::SolrDocument.new(hit) }
         new_order = docs.sort_by do |item|
           if item['sequence_ssm'].present?
             item.sequence_number


### PR DESCRIPTION
This commit will fix an issue that manifests in a blank viewer.  When a resource has a lot of member_ids, the solr request gets so long that Solr can't handle it on a get request.  Instead we change the method to a post so we use a much longer query string.

Ref
- https://github.com/notch8/utk-hyku/issues/817

<img width="1272" height="717" alt="image" src="https://github.com/user-attachments/assets/b9e3c0a1-09d6-45e2-bb11-51897aee5c09" />
