### PR TITLE
💄 Style CloverIIIF viewer height

### DIFF
--- a/public/clover-iiif/index.html
+++ b/public/clover-iiif/index.html
@@ -16,4 +16,26 @@
       <noscript>You need to enable JavaScript to run this app.</noscript>
       <div id="root"></div>
    </body>
+   <style>
+      html,
+      body,
+      #root,
+      .clover-iiif,
+      [data-state="open"],
+      .clover-content,
+      .c-ldcKiQ,
+      .c-gKYThq,
+      .c-LdPyz,
+      .c-LdPyz > div,
+      .c-iHOaIo {
+         height: 100% !important;
+         max-height: none !important;
+      }
+
+      /* Only apply full height to video when clover-canvases doesn't exist */
+      .clover-iiif:not(:has(.clover-canvases)) #clover-iiif-video {
+         height: 100% !important;
+         max-height: none !important;
+      }
+   </style>
 </html>


### PR DESCRIPTION
Prior, the height for an audio resource was very small and did not fill the full iframe.  This fix will add styling to the index.html which overrides the internal CSS.

Ref:
- https://github.com/notch8/utk-hyku/issues/830

## Before
<img width="2510" height="1554" alt="image" src="https://github.com/user-attachments/assets/95de6dfb-d9bc-4a4f-ab28-6c6b668a25d9" />

## After
<img width="1232" height="777" alt="image" src="https://github.com/user-attachments/assets/426f70bc-2119-4e27-9ad5-898d52be1ced" />

## Compound work looks the same as previous
<img width="1252" height="808" alt="image" src="https://github.com/user-attachments/assets/ae0c3c8b-52dd-463f-a862-c5b5c6e8e999" />

## Compound work with video showing looks the same as previous
<img width="1211" height="743" alt="image" src="https://github.com/user-attachments/assets/bd6b1388-3e18-4899-b3b9-64055f2b88fa" />


## Just video looks the same as previous
<img width="1245" height="654" alt="image" src="https://github.com/user-attachments/assets/0c93ca33-7f5e-4a25-a887-e42b40da5268" />
