### PR TITLE
Fix TypeError during export

### DIFF
--- a/app/models/concerns/bulkrax/export_behavior_decorator.rb
+++ b/app/models/concerns/bulkrax/export_behavior_decorator.rb
@@ -16,7 +16,8 @@ module Bulkrax
       ext_mime = ::Marcel::MimeType.for(name: fn)
       # OVERRIDE begin
       if File.extname(fn).blank?
-        filename = "#{file_set.id}_#{fn}" + Rack::Mime::MIME_TYPES.invert[mime]
+        extension = Rack::Mime::MIME_TYPES.invert[mime] || ".#{mime.to_s.split('/').last}"
+        filename = "#{file_set.id}_#{fn}#{extension}"
       elsif fn.include?(file_set.id) || importerexporter.metadata_only?
         # OVERRIDE end
         filename = "#{fn}.#{mime.to_sym}"


### PR DESCRIPTION
# Story

Adjusts the following Line to handle cases where mime type does not have a corresponding file extension and was throwing error: *** TypeError Exception: no implicit conversion of nil into String
```
"#{file_set.id}_#{fn}" + Rack::Mime::MIME_TYPES.invert[mime]

(byebug) file_set.id
"dd3dc9bd-ebe6-4e86-b702-e6232a67562e"
(byebug) fn
"HOCR"
(byebug) mime
"text/xml"
(byebug) Rack::Mime::MIME_TYPES.invert[mime]
nil
```

Refs #824 

This is not the cause of the original failure... that appears to be due to a solr outage. But TypeErrors were thrown while testing locally.

# Expected Behavior Before Changes
Files with mime type `text/xml` resulted in TypeError while trying to generate a filename.
# Expected Behavior After Changes
Filenames are generated for HOCR  `text/xml` files.

# Screenshots / Video

<details>
<summary>Sample file which failed w/ TypeError</summary>

[yearbookKirk.csv](https://github.com/user-attachments/files/24896551/yearbookKirk.csv)

</details>

# Testing

- Import the above CSV file (under screenshots)
- create a new collection and add all of these works to a collection
- create an export, and export the collection
- [ ] all works and filesets should be exported without receiving TypeError

# Notes