### PR TITLE
Add cron job for cleaning up old uploaded files

### DIFF
--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -9,7 +9,7 @@ class CleanupSubDirectoryJob < ApplicationJob
     @files_deleted = 0
     delete_files
     delete_empty_directories
-    Rails.logger.info("Completed #{directory}: checked #{@files_checked}, deleted #{@files_deleted}")
+    logger.info("Completed #{directory}: checked #{@files_checked}, deleted #{@files_deleted}")
   end
 
   private
@@ -20,7 +20,7 @@ class CleanupSubDirectoryJob < ApplicationJob
 
         File.delete(path)
         @files_deleted += 1
-        Rails.logger.info("Checked #{@files_checked}, deleted #{deleted_count} files") if (@files_checked % 100).zero?
+        logger.info("Checked #{@files_checked}, deleted #{deleted_count} files") if (@files_checked % 100).zero?
       end
     end
 
@@ -34,7 +34,7 @@ class CleanupSubDirectoryJob < ApplicationJob
         end
       end
 
-      Rails.logger.info("Completed empty directory cleanup for #{directory}")
+      logger.info("Completed empty directory cleanup for #{directory}")
     end
 
     def should_be_deleted?(path)
@@ -58,11 +58,11 @@ class CleanupSubDirectoryJob < ApplicationJob
       @files_checked += 1
       Account.find_each do |account|
         begin
-          account.switch do
+          Apartment::Tenant.switch(account.tenant) do
             return true if FileSet.exists?(fs_id)
           end
         rescue StandardError => e
-          Rails.logger.error("Error checking FileSet #{fs_id} in tenant #{account.tenant}: #{e.message}")
+          logger.error("Error checking FileSet #{fs_id} in tenant #{account.tenant}: #{e.message}")
         end
       end
 

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -24,8 +24,8 @@ class CleanupSubDirectoryJob < ApplicationJob
       Dir.glob("#{directory}/*/*/*/*/*").select { |d| File.directory?(d) }.each do |dir|
         begin
           FileUtils.rmdir(dir, parents: true)
-        rescue SystemCallError
-          # Directory not empty, ignore
+        rescue Errno::ENOTEMPTY
+          next
         end
       end
 

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -4,6 +4,9 @@
 class CleanupSubDirectoryJob < ApplicationJob
   non_tenant_job
 
+  # Assumptions:
+  # The second to last element in the path is the ID of the associated FileSet
+  # The directory has a pair-tree structure
   attr_reader :delete_ingested_after_days, :delete_all_after_days, :directory, :files_checked, :files_deleted
   def perform(delete_ingested_after_days:, directory:, delete_all_after_days: 730)
     @directory = directory
@@ -30,7 +33,7 @@ class CleanupSubDirectoryJob < ApplicationJob
 
     def delete_empty_directories
       # Find all UUID-level directories (deepest level)
-      Dir.glob("#{directory}/*/*/*/*/*").select { |path| File.directory?(path) }.each do |dir|
+      Dir.glob("#{directory}/*/*/*/*").select { |path| File.directory?(path) }.each do |dir|
         begin
           FileUtils.rmdir(dir, parents: true)
         rescue Errno::ENOTEMPTY

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -20,11 +20,17 @@ class CleanupSubDirectoryJob < ApplicationJob
     end
 
     def should_be_deleted?(path)
-      File.file?(path) && old_enough(path) && fileset_created?(path)
+      File.file?(path) && ((old_enough(path) && fileset_created?(path)) || very_old?(path))
     end
 
     def old_enough(path)
       return true if File.mtime(path) < (Time.zone.now - days_old.to_i.days)
+
+      false
+    end
+
+    def very_old?(path)
+      return true if File.mtime(path) < (Time.zone.now - 2.years)
 
       false
     end

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CleanupSubDirectoryJob < ApplicationJob
+  non_tenant_job
+
   attr_reader :days_old, :directory
   def perform(days_old:, directory:)
     @directory = directory
@@ -20,7 +22,7 @@ class CleanupSubDirectoryJob < ApplicationJob
 
         File.delete(path)
         @files_deleted += 1
-        logger.info("Checked #{@files_checked}, deleted #{deleted_count} files") if (@files_checked % 100).zero?
+        logger.info("Checked #{@files_checked}, deleted #{@files_deleted} files") if (@files_checked % 100).zero?
       end
     end
 

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -12,7 +12,6 @@ class CleanupSubDirectoryJob < ApplicationJob
 
     def delete_files
       Dir.glob("#{directory}/**/*").each do |path|
-        next unless File.file?(path)
         next unless should_be_deleted?(path)
 
         File.delete(path)
@@ -22,6 +21,8 @@ class CleanupSubDirectoryJob < ApplicationJob
     end
 
     def should_be_deleted?(path)
+      return false unless File.file?(path)
+
       return true if very_old?(path)
 
       old_enough?(path) && fileset_created?(path)

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -20,10 +20,10 @@ class CleanupSubDirectoryJob < ApplicationJob
     end
 
     def should_be_deleted?(path)
-      File.file?(path) && ((old_enough(path) && fileset_created?(path)) || very_old?(path))
+      File.file?(path) && ((old_enough?(path) && fileset_created?(path)) || very_old?(path))
     end
 
-    def old_enough(path)
+    def old_enough?(path)
       return true if File.mtime(path) < (Time.zone.now - days_old.to_i.days)
 
       false

--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class CleanupSubDirectoryJob < ApplicationJob
+  attr_reader :days_old, :directory
+  def perform(days_old:, directory:)
+    @directory = directory
+    @days_old = days_old
+    delete_files
+  end
+
+  private
+
+    def delete_files
+      Dir.glob("#{directory}/**/*").each do |path|
+        next unless should_be_deleted?(path)
+
+        File.delete(path)
+        FileUtils.rmdir(parent_directory(path), parents: true) if Dir.empty?(parent_directory(path))
+      end
+    end
+
+    def should_be_deleted?(path)
+      File.file?(path) && old_enough(path) && fileset_created?(path)
+    end
+
+    def old_enough(path)
+      return true if File.mtime(path) < (Time.zone.now - days_old.to_i.days)
+
+      false
+    end
+
+    def parent_directory(path)
+      split_path = path.split('/')
+      split_path[0..-2].join('/')
+    end
+
+    def fileset_created?(path)
+      fs_id = path.split('/')[-2]
+      file_set = FileSet.find(fs_id)
+      return true if file_set&.original_file&.present?
+
+      false
+    rescue ActiveFedora::ObjectNotFoundError
+      false
+    end
+end

--- a/app/jobs/cleanup_upload_files_job.rb
+++ b/app/jobs/cleanup_upload_files_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CleanupUploadFilesJob < ApplicationJob
+  attr_reader :uploads_path
+  def perform(days_old:, uploads_path:)
+    Rails.logger.info("Starting cleanup coordinator for files older than #{days_old} days")
+    @uploads_path = uploads_path
+    Rails.logger.info("Spawning #{top_level_directories.count} cleanup jobs for subdirectories")
+    top_level_directories.map do |dir|
+      CleanupSubDirectoryJob.perform_later(days_old: days_old, directory: dir)
+    end
+  end
+
+  private
+
+    def top_level_directories
+      @top_level_directories ||= Dir.glob("#{uploads_path}/*").select { |path| File.directory?(path) }
+    end
+end

--- a/app/jobs/cleanup_upload_files_job.rb
+++ b/app/jobs/cleanup_upload_files_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CleanupUploadFilesJob < ApplicationJob
+  non_tenant_job
+
   attr_reader :uploads_path
   def perform(days_old:, uploads_path:)
     Rails.logger.info("Starting cleanup coordinator for files older than #{days_old} days")

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,15 +1,23 @@
+# frozen_string_literal: true
 
 Rails.application.configure do
   # Configure options individually...
   config.good_job.preserve_job_records = true
   config.good_job.retry_on_unhandled_error = false
-  config.good_job.on_thread_error = -> (exception) { Raven.capture_exception(exception) }
+  config.good_job.on_thread_error = ->(exception) { Raven.capture_exception(exception) }
   config.good_job.execution_mode = :external
   # config.good_job.queues = '*'
   config.good_job.shutdown_timeout = 60 # seconds
   config.good_job.poll_interval = 5
-  # config.good_job.enable_cron = true
-  # config.good_job.cron = { example: { cron: '0 * * * *', class: 'ExampleJob'  } }
+  config.good_job.enable_cron = true
+  config.good_job.cron = {
+    cleanup_upload_files: {
+      cron: '0 2 * * 0',
+      class: 'CleanupUploadFilesJob',
+      kwargs: { days_old: 180, uploads_path: '/app/samvera/uploads' },
+      enabled_by_default: -> { Rails.env.production? }
+    }
+  }
 end
 
 # Wrapping this in an after_initialize block to ensure that all constants are loaded

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
     cleanup_upload_files: {
       cron: '0 2 * * 0',
       class: 'CleanupUploadFilesJob',
-      kwargs: { days_old: 180, uploads_path: '/app/samvera/uploads' },
+      args: { days_old: 180, uploads_path: '/app/samvera/uploads' },
       enabled_by_default: -> { Rails.env.production? }
     }
   }

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -14,7 +14,9 @@ Rails.application.configure do
     cleanup_upload_files: {
       cron: '0 2 * * 0',
       class: 'CleanupUploadFilesJob',
-      args: { days_old: 180, uploads_path: '/app/samvera/uploads' },
+      # delete_ingested_after_days: delete files with matching FileSets older than this
+      # delete_all_after_days: delete all files, whether or not they have a FileSet, older than this
+      args: { delete_ingested_after_days: 180, uploads_path: '/app/samvera/uploads', delete_all_after_days: 365 },
       enabled_by_default: -> { Rails.env.production? }
     }
   }

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -127,7 +127,7 @@ Hyrax.config do |config|
   # Temporary path to hold uploads before they are ingested into FCrepo.
   # This must be a lambda that returns a Pathname
   config.upload_path = ->() do
-    if Site.account&.s3_bucket
+    if Site.account&.s3_bucket&.present?
       "uploads/#{Apartment::Tenant.current}"
     else
       ENV['HYRAX_UPLOAD_PATH'].present? ? Pathname.new(File.join(ENV['HYRAX_UPLOAD_PATH'], Apartment::Tenant.current)) : Rails.root.join('public', 'uploads', Apartment::Tenant.current)

--- a/spec/jobs/cleanup_sub_directory_job_spec.rb
+++ b/spec/jobs/cleanup_sub_directory_job_spec.rb
@@ -2,12 +2,14 @@
 
 RSpec.describe CleanupSubDirectoryJob do
   let(:old_time) { Time.zone.now - 1.year }
+  let(:very_old_time) { Time.zone.now - 3.years }
   let(:new_time) { Time.zone.now - 1.week }
   let(:path_1) { '/app/samvera/uploads/ff/00/27/d1/file-set-id-1/path_1' }
   let(:path_2) { '/app/samvera/uploads/ff/11/28/19/file-set-id-2/path_2' }
   let(:path_3) { '/app/samvera/uploads/ff/22/17/de/file-set-id-3/path_3' }
   let(:path_4) { '/app/samvera/uploads/ff/33/0d/6b/file-set-id-4/path_4' }
   let(:path_5) { '/app/samvera/uploads/ff/f4/11/30/file-set-id-5/path_5' }
+  let(:path_6) { '/app/samvera/uploads/ff/a1/b2/c3/file-set-id-6/path_6' }
   let(:account_1) { FactoryBot.create(:account) }
   let(:account_2) { FactoryBot.create(:account) }
 
@@ -17,7 +19,7 @@ RSpec.describe CleanupSubDirectoryJob do
     allow(Apartment::Tenant).to receive(:switch).with(account_2.tenant).and_return(true)
     allow(Dir).to receive(:glob).and_call_original
     allow(Dir).to receive(:glob).with('/app/samvera/uploads/ff/**/*').and_return([path_5, path_1, path_2,
-                                                                                  path_3, path_4])
+                                                                                  path_3, path_4, path_6])
 
     allow(Dir).to receive(:empty?).and_return(true)
     allow(FileUtils).to receive(:rmdir)
@@ -32,22 +34,50 @@ RSpec.describe CleanupSubDirectoryJob do
     allow(File).to receive(:file?).with(path_4).and_return(false)
     allow(File).to receive(:file?).with(path_5).and_return(true)
     allow(File).to receive(:mtime).with(path_5).and_return(old_time)
+    allow(File).to receive(:file?).with(path_6).and_return(true)
+    allow(File).to receive(:mtime).with(path_6).and_return(very_old_time)
     allow(FileSet).to receive(:exists?).with('file-set-id-1').and_return(true)
     allow(FileSet).to receive(:exists?).with('file-set-id-2').and_return(true)
     allow(FileSet).to receive(:exists?).with('file-set-id-5').and_return(false)
+    allow(FileSet).to receive(:exists?).with('file-set-id-6').and_return(false)
   end
-  it 'deletes files ' do
+
+  it 'deletes old files with matching FileSets' do
     expect(File).to receive(:delete).with(path_1)
     expect(File).to receive(:delete).with(path_2)
-    # # Too new
-    expect(File).not_to receive(:delete).with(path_3)
-    # # Not a file
-    expect(File).not_to receive(:delete).with(path_4)
-    # # Does not have a FileSet yet
-    expect(File).not_to receive(:delete).with(path_5)
-    # expect(FileSet).to receive(:find).with('file-set-id-5')
-    described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
+    described_class.perform_now(delete_ingested_after_days: 180, directory: '/app/samvera/uploads/ff')
   end
+
+  it 'does not delete files newer than delete_ingested_after_days threshold' do
+    expect(File).not_to receive(:delete).with(path_3)
+    described_class.perform_now(delete_ingested_after_days: 180, directory: '/app/samvera/uploads/ff')
+  end
+
+  it 'does not delete directories' do
+    expect(File).not_to receive(:delete).with(path_4)
+    described_class.perform_now(delete_ingested_after_days: 180, directory: '/app/samvera/uploads/ff')
+  end
+
+  it 'does not delete old files without matching FileSets (orphaned but not old enough)' do
+    expect(File).not_to receive(:delete).with(path_5)
+    described_class.perform_now(delete_ingested_after_days: 180, directory: '/app/samvera/uploads/ff')
+  end
+
+  it 'deletes orphaned files older than delete_all_after_days' do
+    expect(File).to receive(:delete).with(path_6)
+    described_class.perform_now(delete_ingested_after_days: 180,
+                                directory: '/app/samvera/uploads/ff',
+                                delete_all_after_days: 730)
+  end
+
+  it 'uses configurable delete_all_after_days threshold' do
+    # With delete_all_after_days: 300, path_5 (1 year old) should be deleted
+    expect(File).to receive(:delete).with(path_5)
+    described_class.perform_now(delete_ingested_after_days: 180,
+                                directory: '/app/samvera/uploads/ff',
+                                delete_all_after_days: 300)
+  end
+
   describe 'cleaning up directories' do
     before do
       allow(Dir).to receive(:glob).with("/app/samvera/uploads/ff/*/*/*/*/*")
@@ -70,7 +100,7 @@ RSpec.describe CleanupSubDirectoryJob do
       expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/11/28/19/file-set-id-2', parents: true)
       expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/22/17/de/file-set-id-3', parents: true)
 
-      described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
+      described_class.perform_now(delete_ingested_after_days: 180, directory: '/app/samvera/uploads/ff')
     end
   end
 end

--- a/spec/jobs/cleanup_sub_directory_job_spec.rb
+++ b/spec/jobs/cleanup_sub_directory_job_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe CleanupSubDirectoryJob do
+  let(:old_time) { Time.zone.now - 1.year }
+  let(:new_time) { Time.zone.now - 1.week }
+  let(:fs_double) { instance_double(FileSet, original_file: true) }
+  let(:path_1) { '/app/samvera/uploads/ff/00/27/d1/file-set-id-1/path_1' }
+  let(:path_2) { '/app/samvera/uploads/ff/11/28/19/file-set-id-2/path_2' }
+  let(:path_3) { '/app/samvera/uploads/ff/22/17/de/file-set-id-3/path_3' }
+  let(:path_4) { '/app/samvera/uploads/ff/33/0d/6b/file-set-id-4/path_4' }
+  let(:path_5) { '/app/samvera/uploads/ff/f4/11/30/file-set-id-5/path_5' }
+
+  before do
+    allow(Dir).to receive(:glob).and_call_original
+    allow(Dir).to receive(:glob).with('/app/samvera/uploads/ff/**/*').and_return([path_5, path_1, path_2,
+                                                                                  path_3, path_4])
+    allow(Dir).to receive(:empty?).and_return(true)
+    allow(FileUtils).to receive(:rmdir)
+    allow(File).to receive(:file?).and_call_original
+    allow(File).to receive(:delete)
+    allow(File).to receive(:file?).with(path_1).and_return(true)
+    allow(File).to receive(:mtime).with(path_1).and_return(old_time)
+    allow(File).to receive(:file?).with(path_2).and_return(true)
+    allow(File).to receive(:mtime).with(path_2).and_return(old_time)
+    allow(File).to receive(:file?).with(path_3).and_return(true)
+    allow(File).to receive(:mtime).with(path_3).and_return(new_time)
+    allow(File).to receive(:file?).with(path_4).and_return(false)
+    allow(File).to receive(:file?).with(path_5).and_return(true)
+    allow(File).to receive(:mtime).with(path_5).and_return(old_time)
+    allow(FileSet).to receive(:find).with('file-set-id-1').and_return(fs_double)
+    allow(FileSet).to receive(:find).with('file-set-id-2').and_return(fs_double)
+    allow(FileSet).to receive(:find).with('file-set-id-5').and_raise(ActiveFedora::ObjectNotFoundError)
+  end
+  it 'deletes files ' do
+    expect(File).to receive(:delete).with(path_1)
+    expect(File).to receive(:delete).with(path_2)
+    # Too new
+    expect(File).not_to receive(:delete).with(path_3)
+    # Not a file
+    expect(File).not_to receive(:delete).with(path_4)
+    # Does not have a FileSet yet
+    expect(File).not_to receive(:delete).with(path_5)
+    expect(FileSet).to receive(:find).with('file-set-id-5')
+    described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
+  end
+
+  it 'cleans up empty parent directories' do
+    expect(Dir).to receive(:empty?).with('/app/samvera/uploads/ff/00/27/d1/file-set-id-1')
+    expect(Dir).to receive(:empty?).with('/app/samvera/uploads/ff/11/28/19/file-set-id-2')
+
+    # expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/00/27/d1/file-set-id-1')
+    described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
+  end
+end

--- a/spec/jobs/cleanup_sub_directory_job_spec.rb
+++ b/spec/jobs/cleanup_sub_directory_job_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe CleanupSubDirectoryJob do
 
   describe 'cleaning up directories' do
     before do
-      allow(Dir).to receive(:glob).with("/app/samvera/uploads/ff/*/*/*/*/*")
+      allow(Dir).to receive(:glob).with("/app/samvera/uploads/ff/*/*/*/*")
                                   .and_return([
                                                 '/app/samvera/uploads/ff/00/27/d1/file-set-id-1',
                                                 '/app/samvera/uploads/ff/11/28/19/file-set-id-2',

--- a/spec/jobs/cleanup_sub_directory_job_spec.rb
+++ b/spec/jobs/cleanup_sub_directory_job_spec.rb
@@ -8,9 +8,13 @@ RSpec.describe CleanupSubDirectoryJob do
   let(:path_3) { '/app/samvera/uploads/ff/22/17/de/file-set-id-3/path_3' }
   let(:path_4) { '/app/samvera/uploads/ff/33/0d/6b/file-set-id-4/path_4' }
   let(:path_5) { '/app/samvera/uploads/ff/f4/11/30/file-set-id-5/path_5' }
+  let(:account_1) { FactoryBot.create(:account) }
+  let(:account_2) { FactoryBot.create(:account) }
 
   before do
-    2.times { FactoryBot.create(:account) }
+    allow(Apartment::Tenant).to receive(:switch).and_call_original
+    allow(Apartment::Tenant).to receive(:switch).with(account_1.tenant).and_yield
+    allow(Apartment::Tenant).to receive(:switch).with(account_2.tenant).and_return(true)
     allow(Dir).to receive(:glob).and_call_original
     allow(Dir).to receive(:glob).with('/app/samvera/uploads/ff/**/*').and_return([path_5, path_1, path_2,
                                                                                   path_3, path_4])

--- a/spec/jobs/cleanup_sub_directory_job_spec.rb
+++ b/spec/jobs/cleanup_sub_directory_job_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe CleanupSubDirectoryJob do
     allow(Dir).to receive(:glob).and_call_original
     allow(Dir).to receive(:glob).with('/app/samvera/uploads/ff/**/*').and_return([path_5, path_1, path_2,
                                                                                   path_3, path_4])
+
     allow(Dir).to receive(:empty?).and_return(true)
     allow(FileUtils).to receive(:rmdir)
     allow(File).to receive(:file?).and_call_original
@@ -43,12 +44,29 @@ RSpec.describe CleanupSubDirectoryJob do
     # expect(FileSet).to receive(:find).with('file-set-id-5')
     described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
   end
+  describe 'cleaning up directories' do
+    before do
+      allow(Dir).to receive(:glob).with("/app/samvera/uploads/ff/*/*/*/*/*")
+                                  .and_return([
+                                                '/app/samvera/uploads/ff/00/27/d1/file-set-id-1',
+                                                '/app/samvera/uploads/ff/11/28/19/file-set-id-2',
+                                                '/app/samvera/uploads/ff/22/17/de/file-set-id-3'
+                                              ])
+      allow(File).to receive(:directory?).and_call_original
+      allow(File).to receive(:directory?).with('/app/samvera/uploads/ff/00/27/d1/file-set-id-1').and_return(true)
+      allow(File).to receive(:directory?).with('/app/samvera/uploads/ff/11/28/19/file-set-id-2').and_return(true)
+      allow(File).to receive(:directory?).with('/app/samvera/uploads/ff/22/17/de/file-set-id-3').and_return(true)
+      allow(FileUtils).to receive(:rmdir)
+        .with('/app/samvera/uploads/ff/11/28/19/file-set-id-2', parents: true)
+        .and_raise(Errno::ENOTEMPTY)
+    end
 
-  it 'cleans up empty parent directories' do
-    expect(Dir).to receive(:empty?).with('/app/samvera/uploads/ff/00/27/d1/file-set-id-1')
-    expect(Dir).to receive(:empty?).with('/app/samvera/uploads/ff/11/28/19/file-set-id-2')
+    it 'cleans up empty parent directories' do
+      expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/00/27/d1/file-set-id-1', parents: true)
+      expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/11/28/19/file-set-id-2', parents: true)
+      expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/22/17/de/file-set-id-3', parents: true)
 
-    # expect(FileUtils).to receive(:rmdir).with('/app/samvera/uploads/ff/00/27/d1/file-set-id-1')
-    described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
+      described_class.perform_now(days_old: 180, directory: '/app/samvera/uploads/ff')
+    end
   end
 end

--- a/spec/jobs/cleanup_upload_files_job_spec.rb
+++ b/spec/jobs/cleanup_upload_files_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe CleanupUploadFilesJob do
+  before do
+    allow(Dir).to receive(:glob).and_call_original
+    allow(Dir).to receive(:glob).with('/app/samvera/uploads/*').and_return(['path_1', 'path_2', 'path_3', 'path_4'])
+    allow(File).to receive(:directory?).and_call_original
+    allow(File).to receive(:directory?).with('path_1').and_return(true)
+    allow(File).to receive(:directory?).with('path_2').and_return(true)
+    allow(File).to receive(:directory?).with('path_3').and_return(true)
+    allow(File).to receive(:directory?).with('path_4').and_return(false)
+  end
+
+  it 'spawns child jobs for each sub-directory' do
+    expect { described_class.perform_now(days_old: 180, uploads_path: '/app/samvera/uploads') }
+      .to have_enqueued_job(CleanupSubDirectoryJob).exactly(3).times
+  end
+end


### PR DESCRIPTION
# Story
On ingestion, sometimes the temporary uploaded file is persisted to an unexpected location, and does not get cleaned up. 

This PR adds a cron job for cleaning up the old uploaded files that already have a FileSet created.

The first job just kicks off child jobs, one for each sub-directory, so that if a job gets interrupted for whatever reason we don't have to traverse the entire directory tree again. It also allows for multiple threads. 

The second job traverses a sub-directory, finds files, and checks their age. 

If the file is very old - older than 2 years, it's deleted.

If the file is older than the `days_old` argument, then it is only deleted if it has a FileSet created in one of the tenants. 

Tested successfully on r2-friends deployment.

Connected to https://github.com/notch8/dev-ops/issues/1090