### PR TITLE
Fix cleanup jobs to work correctly across tenants

### DIFF
--- a/app/jobs/cleanup_sub_directory_job.rb
+++ b/app/jobs/cleanup_sub_directory_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CleanupSubDirectoryJob < ApplicationJob
+  non_tenant_job
+
   attr_reader :days_old, :directory
   def perform(days_old:, directory:)
     @directory = directory
@@ -20,7 +22,7 @@ class CleanupSubDirectoryJob < ApplicationJob
 
         File.delete(path)
         @files_deleted += 1
-        logger.info("Checked #{@files_checked}, deleted #{deleted_count} files") if (@files_checked % 100).zero?
+        logger.info("Checked #{@files_checked}, deleted #{@files_deleted} files") if (@files_checked % 100).zero?
       end
     end
 

--- a/app/jobs/cleanup_upload_files_job.rb
+++ b/app/jobs/cleanup_upload_files_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CleanupUploadFilesJob < ApplicationJob
+  non_tenant_job
+
   attr_reader :uploads_path
   def perform(days_old:, uploads_path:)
     Rails.logger.info("Starting cleanup coordinator for files older than #{days_old} days")


### PR DESCRIPTION
- Add non_tenant_job to CleanupUploadFilesJob and CleanupSubDirectoryJob These jobs need to operate outside tenant context since they iterate through all tenants to check for FileSet existence. Without this, the jobs run in a serialized tenant context which interferes with the nested tenant switching in fileset_created?.

- Fix typo: deleted_count -> @files_deleted This undefined variable would cause a NameError when logging, crashing the job and preventing remaining files from being processed.

https://claude.ai/code/session_019Tfuwpbc2cYDnHHTjF6opJ