### PR TITLE
Increase prod worker memory limit

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -204,7 +204,7 @@ worker:
   replicaCount: 2
   resources:
     limits:
-      memory: 7Gi
+      memory: 12Gi
       cpu: 1.5
     requests:
       memory: 6Gi


### PR DESCRIPTION
With the nested index jobs the workers are getting OOMKilled. Increased via Rancher UI. This makes the code match what's currently deployed on production.
