### PR TITLE
Increase prod memory to avoid OOMKills, increase pods

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -3,7 +3,7 @@ replicaCount: 3
 resources:
   limits:
     memory: 6Gi
-    cpu: 1
+    cpu: 2
   requests:
     memory: 4Gi
     cpu: 100m
@@ -13,8 +13,10 @@ livenessProbe:
 readinessProbe:
   enabled: true
   path: "/healthz"
+  initialDelaySeconds: 15
   periodSeconds: 30
-  timeoutSeconds: 10
+  timeoutSeconds: 30
+  failureThreshold: 6
 
 brandingVolume:
   storageClass: efs-sc
@@ -183,7 +185,7 @@ extraEnvVars: &envVars
   - name: RAILS_LOG_TO_STDOUT
     value: "true"
   - name: RAILS_MAX_THREADS
-    value: "5"
+    value: "12"
   - name: RAILS_SERVE_STATIC_FILES
     value: "true"
   - name: REDIS_HOST

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -1,11 +1,11 @@
-replicaCount: 2
+replicaCount: 3
 
 resources:
   limits:
-    memory: 4Gi
+    memory: 6Gi
     cpu: 1
   requests:
-    memory: 3Gi
+    memory: 4Gi
     cpu: 100m
 
 livenessProbe:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,3 +3,10 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+# Every item/collection page is also reachable with an explicit ?locale=
+# param for each supported language, multiplying the crawlable surface by
+# ~7x for duplicate content. Block the locale-parameterized URLs so
+# compliant crawlers only index the canonical (default-locale) page.
+User-agent: *
+Disallow: /*locale=


### PR DESCRIPTION
Production keeps going down - reporting unhealthy health checks and OOMKills - trying increasing production resources until root causes can be addressed.